### PR TITLE
:sparkles: Add LTO support

### DIFF
--- a/cmake/link_time_optimization.cmake
+++ b/cmake/link_time_optimization.cmake
@@ -1,0 +1,29 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Use -Og which is like O1 with some changes to reduce code size and improve
+# performance but still provide a great debugability. This should be used
+# instead of the "Debug" build type.
+
+list(APPEND CMAKE_C_FLAGS_DEBUG "-flto")
+list(APPEND CMAKE_CXX_FLAGS_DEBUG "-flto")
+
+list(APPEND CMAKE_C_FLAGS_RELEASE "-flto")
+list(APPEND CMAKE_CXX_FLAGS_RELEASE "-flto")
+
+list(APPEND CMAKE_C_FLAGS_MINSIZEREL "-flto")
+list(APPEND CMAKE_CXX_FLAGS_MINSIZEREL "-flto")
+
+list(APPEND CMAKE_C_FLAGS_RELWITHDEBINFO "-flto")
+list(APPEND CMAKE_CXX_FLAGS_RELWITHDEBINFO "-flto")

--- a/conanfile.py
+++ b/conanfile.py
@@ -23,7 +23,7 @@ required_conan_version = ">=1.50.0"
 
 class libhal_cmake_util_conan(ConanFile):
     name = "libhal-cmake-util"
-    version = "1.0.0"
+    version = "1.1.0"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://libhal.github.io/libhal-armcortex"
@@ -33,11 +33,13 @@ class libhal_cmake_util_conan(ConanFile):
     no_copy_source = True
     options = {
         "add_build_outputs": [True, False],
-        "optimize_debug_build": [True, False]
+        "optimize_debug_build": [True, False],
+        "link_time_optimization": [True, False]
     }
     default_options = {
         "add_build_outputs": True,
-        "optimize_debug_build": True
+        "optimize_debug_build": True,
+        "link_time_optimization": True
     }
 
     def package_id(self):
@@ -59,6 +61,8 @@ class libhal_cmake_util_conan(ConanFile):
             self.package_folder, "cmake/build_outputs.cmake")
         optimize_debug_build_path = os.path.join(
             self.package_folder, "cmake/optimize_debug_build.cmake")
+        link_time_optimization_path = os.path.join(
+            self.package_folder, "cmake/link_time_optimization.cmake")
 
         if self.options.add_build_outputs:
             self.conf_info.append(
@@ -70,7 +74,14 @@ class libhal_cmake_util_conan(ConanFile):
                 "tools.cmake.cmaketoolchain:user_toolchain",
                 optimize_debug_build_path)
 
+        if self.options.link_time_optimization:
+            self.conf_info.append(
+                "tools.cmake.cmaketoolchain:user_toolchain",
+                link_time_optimization_path)
+
         self.output.info(
             f"add_build_outputs: {self.options.add_build_outputs}")
         self.output.info(
             f"optimize_debug_build: {self.options.optimize_debug_build}")
+        self.output.info(
+            f"link_time_optimization: {self.options.link_time_optimization}")


### PR DESCRIPTION
LTO is default enabled in cmake-util in order to enable it for all builds. It will NOT be enabled for the linker. This gives the developer the option to turn on/off LTO at the linker stage.

When LTO is not used at the linker, all of the LTO information in the archive and library files gets eliminated.