### PR TITLE
:sparkles: Add libhal_build_demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,8 @@ This package automatically injects libhal cmake utility functions:
 
 ### `libhal_test_and_make_library()`
 
-Build and validate unit tests and build packages
-
-It is recommended to use this function rather than libhal_unit_test and
-libhal_make_library separately.
+Builds and tests a library. This function must be used in place of using
+libhal_unit_test and libhal_make_library separately.
 
 ```cmake
 libhal_test_and_make_library([LIBRARY_NAME <library_name>]
@@ -136,10 +134,10 @@ def build_requirements(self):
 
 ### `libhal_unit_test()`
 
-This function builds and executes unit tests for libhal. Use this for header
-only libraries that do not generate library files, but do have buildable unit
-tests. If non-test source files are present, then the libhal package MUST use
-the `libhal_test_and_make_library()` function.
+Builds and executes unit tests for libhal. Use this for header only libraries
+that do not generate library files, but do have build-able unit tests. If
+non-test source files are present, then the libhal package MUST use the
+`libhal_test_and_make_library()` function.
 
 ```cmake
 libhal_unit_test([SOURCES <files...>]
@@ -190,8 +188,8 @@ as a package. In conan, add this to your `build_requirements()` method:
 
 ### `libhal_make_library()`
 
-This function builds libhal libraries. Use this when building a libhal package,
-where unit tests are not available or not necessary.
+Builds libhal libraries. Use this when unit tests are not available or necessary
+but a package must be built.
 
 ```cmake
 libhal_make_library([LIBRARY_NAME <library_name>]
@@ -209,6 +207,54 @@ libhal_make_library([LIBRARY_NAME <library_name>]
   package build.
 - `LINK_LIBRARIES` list of the libraries to link into the library.
 - `USE_CLANG_TIDY` use this option to enable clang tidy checks for libraries.
+
+### `libhal_build_demos()`
+
+Builds a set of demos.
+
+For this function to work, the directory structure must fit the following:
+
+```tree
+demos/
+├── CMakeLists.txt
+├── applications
+│   ├── adc.cpp
+│   ├── blinker.cpp
+│   ├── can.cpp
+│   ├── gpio.cpp
+│   ├── i2c.cpp
+│   ├── interrupt_pin.cpp
+│   ├── pwm.cpp
+│   ├── spi.cpp
+│   ├── ...
+│   └── uart.cpp
+└── main.cpp
+```
+
+Where main contains the startup code and calls a common function that is
+implemented across the demos in the `applications`` directory.
+
+```cmake
+libhal_build_demos([LIBRARY_NAME <library_name>]
+                    [INCLUDES <directories...>]
+                    [PACKAGES <packages...>]
+                    [LINK_LIBRARIES <link_libraries...>]
+                    [LINK_FLAGS <link_flags...>]
+                    DISABLE_CLANG_TIDY)
+```
+
+- `DEMOS` names of the demos in the `application/` directory. The names must
+  corrispond to the names of the `.cpp` files in the directory. For example,
+  a demo name of `adc` must have a `adc.cpp` file in the `application/`
+  directory.
+- `INCLUDES` list of include directories. The list has no default and is
+  empty.
+- `PACKAGES` list of packages to automatically find and make available for the
+  package build.
+- `LINK_LIBRARIES` list of the libraries to link into the library.
+- `LINK_FLAGS` linker flags for the demos.
+- `DISABLE_CLANG_TIDY` option is used to disable clang-tidy checks for host
+  builds.
 
 ## Contributing
 

--- a/cmake/build.cmake
+++ b/cmake/build.cmake
@@ -16,7 +16,50 @@ include(CheckCXXCompilerFlag)
 
 # Save the path of this file resides, where ever conan (or any other package
 # manger) puts it.
-set(LIBHAL_CMAK_PATH ${CMAKE_CURRENT_LIST_DIR})
+set(LIBHAL_SCRIPT_PATH ${CMAKE_CURRENT_LIST_DIR})
+
+# Check if clang-tidy exists on the system and if so, evaluate each file
+# against
+find_program(LIBHAL_CLANG_TIDY_PROGRAM NAMES "clang-tidy")
+
+# If ti exists, add it as an additional check for each source file
+if(DEFINED LIBHAL_CLANG_TIDY_PROGRAM)
+  message(STATUS "LIBHAL: clang-tidy AVAILABLE!")
+  set(LIBHAL_CLANG_TIDY_CONFIG_FILE
+    "${LIBHAL_SCRIPT_PATH}/clang-tidy.conf")
+  set(LIBHAL_CLANG_TIDY "${LIBHAL_CLANG_TIDY_PROGRAM}"
+    "--config-file=${LIBHAL_CLANG_TIDY_CONFIG_FILE}")
+else()
+  message(WARNING
+    "LIBHAL:'clang-tidy' program is NOT available! Install it to run checks!")
+endif(DEFINED LIBHAL_CLANG_TIDY_PROGRAM)
+
+# Adds clang tidy check to target for host builds (skipped if a cross build)
+function(_libhal_add_clang_tidy_check TARGET)
+  if(NOT ${CMAKE_CROSSCOMPILING})
+    set_target_properties(${TARGET} PROPERTIES CXX_CLANG_TIDY
+      "${LIBHAL_CLANG_TIDY}")
+  else()
+    message(STATUS
+      "LIBHAL: Cross compiling, skipping clang-tidy checks for \"${TARGET}\"")
+  endif()
+endfunction()
+
+function(_libhal_using_picolibc result_var)
+  string(FIND
+    "${CMAKE_EXE_LINKER_FLAGS_INIT}"
+    "--specs=picolibc.specs"
+    position
+  )
+
+  if(NOT ${position} EQUAL -1)
+    message(STATUS "picolibc found!")
+    set(${result_var} TRUE PARENT_SCOPE)
+  else()
+    message(STATUS "NO picolibc")
+    set(${result_var} FALSE PARENT_SCOPE)
+  endif()
+endfunction()
 
 function(libhal_make_library)
   # Parse CMake function arguments
@@ -34,6 +77,7 @@ function(libhal_make_library)
   endforeach()
 
   add_library(${LIBRARY_ARGS_LIBRARY_NAME} ${LIBRARY_ARGS_SOURCES})
+  _libhal_add_clang_tidy_check(${LIBRARY_ARGS_LIBRARY_NAME})
   target_include_directories(${LIBRARY_ARGS_LIBRARY_NAME} PUBLIC
     include
     src
@@ -48,23 +92,6 @@ function(libhal_make_library)
   target_link_libraries(${LIBRARY_ARGS_LIBRARY_NAME} PUBLIC
     ${LIBRARY_ARGS_LINK_LIBRARIES})
   install(TARGETS ${LIBRARY_ARGS_LIBRARY_NAME})
-
-  if(${LIBRARY_ARGS_USE_CLANG_TIDY})
-    # Check if clang-tidy exists on the system and if so, evaluate each file
-    # against
-    find_program(clang_tidy_exe NAMES "clang-tidy")
-
-    # If ti exists, add it as an additional check for each source file
-    if(DEFINED clang_tidy_exe)
-      message(STATUS "libhal[unit test]: Using clang-tidy")
-      set(config_file "${LIBHAL_CMAK_PATH}/clang-tidy.conf")
-      set(clang_tidy "${clang_tidy_exe}" "--config-file=${config_file}")
-      set_target_properties(${LIBRARY_ARGS_LIBRARY_NAME} PROPERTIES
-        CXX_CLANG_TIDY "${clang_tidy}")
-    else()
-      message(WARNING "'clang-tidy' not available! Install it to run checks!")
-    endif(DEFINED clang_tidy_exe)
-  endif()
 endfunction()
 
 function(libhal_unit_test)
@@ -86,6 +113,24 @@ function(libhal_unit_test)
   endforeach()
 
   add_executable(unit_test ${UNIT_TEST_ARGS_SOURCES})
+
+  # By the end of the this block, CMAKE_REQUIRED_LINK_OPTIONS will be reset to
+  # its original value
+  block()
+  set(CMAKE_REQUIRED_LINK_OPTIONS -fsanitize=address)
+  check_cxx_compiler_flag(-fsanitize=address ADDRESS_SANITIZER_SUPPORT)
+  endblock()
+
+  if(${ADDRESS_SANITIZER_SUPPORT})
+    message(STATUS "LIBHAL: Address Sanitizer available! Using it for tests!")
+    target_compile_options(unit_test PRIVATE -fsanitize=address)
+    target_link_options(unit_test PRIVATE -fsanitize=address)
+  else()
+    message(STATUS "LIBHAL: Address Sanitizer not supported!")
+  endif(${ADDRESS_SANITIZER_SUPPORT})
+
+  _libhal_add_clang_tidy_check(unit_test)
+
   target_include_directories(unit_test PUBLIC include tests src
     ${UNIT_TEST_ARGS_INCLUDES})
   target_compile_features(unit_test PRIVATE cxx_std_20)
@@ -110,35 +155,6 @@ function(libhal_unit_test)
   target_link_libraries(unit_test PRIVATE
     boost-ext-ut::ut
     ${UNIT_TEST_ARGS_LINK_LIBRARIES})
-
-  # By the end of the this block, CMAKE_REQUIRED_LINK_OPTIONS will be reset to
-  # its original value
-  block()
-  set(CMAKE_REQUIRED_LINK_OPTIONS -fsanitize=address)
-  check_cxx_compiler_flag(-fsanitize=address ADDRESS_SANITIZER_SUPPORT)
-  endblock()
-
-  if(${ADDRESS_SANITIZER_SUPPORT})
-    message(STATUS "libhal[unit test]: Using Address Sanitizer")
-    target_compile_options(unit_test PRIVATE -fsanitize=address)
-    target_link_options(unit_test PRIVATE -fsanitize=address)
-  else()
-    message(WARNING "libhal[unit test]: Address Sanitizer not supported!")
-  endif(${ADDRESS_SANITIZER_SUPPORT})
-
-  # Check if clang-tidy exists on the system and if so, evaluate each file
-  # against
-  find_program(clang_tidy_exe NAMES "clang-tidy")
-
-  # If ti exists, add it as an additional check for each source file
-  if(DEFINED clang_tidy_exe)
-    message(STATUS "libhal[unit test]: Using clang-tidy")
-    set(config_file "${LIBHAL_CMAK_PATH}/clang-tidy.conf")
-    set(clang_tidy "${clang_tidy_exe}" "--config-file=${config_file}")
-    set_target_properties(unit_test PROPERTIES CXX_CLANG_TIDY "${clang_tidy}")
-  else()
-    message(WARNING "'clang-tidy' not available! Install it to run checks!")
-  endif(DEFINED clang_tidy_exe)
 
   add_custom_target(run_tests ALL DEPENDS unit_test COMMAND unit_test)
 endfunction()
@@ -169,4 +185,74 @@ function(libhal_test_and_make_library)
     PACKAGES ${BUILD_ARGS_PACKAGES}
     LINK_LIBRARIES ${BUILD_ARGS_LINK_LIBRARIES}
   )
+endfunction()
+
+function(libhal_build_demos)
+  # Parse CMake function arguments
+  set(options DISABLE_CLANG_TIDY)
+  set(one_value_args)
+  set(multi_value_args DEMOS INCLUDES PACKAGES LINK_LIBRARIES LINK_FLAGS)
+  cmake_parse_arguments(DEMO_ARGS
+    "${options}"
+    "${one_value_args}"
+    "${multi_value_args}"
+    ${ARGN})
+
+  foreach(PACKAGE ${DEMO_ARGS_PACKAGES})
+    find_package(${PACKAGE} REQUIRED)
+  endforeach()
+
+  add_library(startup_code main.cpp)
+  target_compile_features(startup_code PRIVATE cxx_std_20)
+  target_include_directories(startup_code PUBLIC ${DEMO_ARGS_INCLUDES})
+  target_compile_options(startup_code PRIVATE
+    -g
+    -Werror
+    -Wall
+    -Wextra
+    -Wshadow
+  )
+  target_link_libraries(startup_code PRIVATE libhal::lpc40)
+
+  if(NOT ${DEMO_ARGS_DISABLE_CLANG_TIDY})
+    _libhal_add_clang_tidy_check(startup_code)
+  endif()
+
+  foreach(demo ${DEMO_ARGS_DEMOS})
+    set(elf ${demo}.elf)
+    message(STATUS "LIBHAL: Generating Demo for \"${elf}\"")
+    add_executable(${elf} ${CMAKE_SOURCE_DIR}/applications/${demo}.cpp)
+    target_compile_features(${elf} PRIVATE cxx_std_20)
+    target_include_directories(${elf} PUBLIC ${DEMO_ARGS_INCLUDES})
+    target_compile_options(${elf} PRIVATE
+      -g
+      -Werror
+      -Wall
+      -Wextra
+      -Wshadow
+    )
+    target_link_libraries(${elf} PRIVATE
+      startup_code
+      ${DEMO_ARGS_LINK_LIBRARIES})
+
+    if(${CMAKE_CROSSCOMPILING})
+      _libhal_using_picolibc(using_picolibc)
+
+      if("${DEMO_ARGS_LINK_FLAGS}" STREQUAL "" AND ${using_picolibc})
+        # Inject picolibc minimal startup code for application
+        set(DEMO_ARGS_LINK_FLAGS --oslib=semihost --crt0=minimal)
+      endif()
+
+      target_link_options(${elf} PRIVATE ${DEMO_ARGS_LINK_FLAGS})
+
+      # Convert elf into .bin, .hex and other formats needed for programming
+      # devices.
+      libhal_post_build(${elf})
+      libhal_disassemble(${elf})
+    endif()
+
+    if(NOT ${DEMO_ARGS_DISABLE_CLANG_TIDY})
+      _libhal_add_clang_tidy_check(${elf})
+    endif()
+  endforeach()
 endfunction()

--- a/conanfile.py
+++ b/conanfile.py
@@ -23,7 +23,7 @@ required_conan_version = ">=2.0.6"
 
 class libhal_cmake_util_conan(ConanFile):
     name = "libhal-cmake-util"
-    version = "2.0.0"
+    version = "2.1.0"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://libhal.github.io/libhal-armcortex"


### PR DESCRIPTION
A reusable utility for building libhal demos. Only supports platform demos currently.

- Bump version to 2.1.0