### PR TITLE
:fire: Remove picolibc detection

### DIFF
--- a/cmake/build.cmake
+++ b/cmake/build.cmake
@@ -66,22 +66,6 @@ function(_libhal_add_clang_tidy_check TARGET)
   endif()
 endfunction()
 
-function(_libhal_using_picolibc result_var)
-  string(FIND
-    "${CMAKE_EXE_LINKER_FLAGS_INIT}"
-    "--specs=picolibc.specs"
-    position
-  )
-
-  if(NOT ${position} EQUAL -1)
-    message(STATUS "picolibc found!")
-    set(${result_var} TRUE PARENT_SCOPE)
-  else()
-    message(STATUS "NO picolibc")
-    set(${result_var} FALSE PARENT_SCOPE)
-  endif()
-endfunction()
-
 function(libhal_make_library)
   # Parse CMake function arguments
   set(options USE_CLANG_TIDY)
@@ -293,15 +277,7 @@ function(libhal_build_demos)
     )
 
     if(${CMAKE_CROSSCOMPILING})
-      _libhal_using_picolibc(using_picolibc)
-
-      if("${DEMO_ARGS_LINK_FLAGS}" STREQUAL "" AND ${using_picolibc})
-        # Inject picolibc minimal startup code for application
-        set(DEMO_ARGS_LINK_FLAGS --oslib=semihost --crt0=minimal)
-      endif()
-
       target_link_options(${elf} PRIVATE ${DEMO_ARGS_LINK_FLAGS})
-
       # Convert elf into .bin, .hex and other formats needed for programming
       # devices.
       libhal_post_build(${elf})

--- a/conanfile.py
+++ b/conanfile.py
@@ -23,7 +23,7 @@ required_conan_version = ">=2.0.6"
 
 class libhal_cmake_util_conan(ConanFile):
     name = "libhal-cmake-util"
-    version = "3.0.1"
+    version = "4.0.0"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://libhal.github.io/libhal-armcortex"
@@ -85,7 +85,6 @@ class libhal_cmake_util_conan(ConanFile):
         self.conf_info.append(
             "tools.cmake.cmaketoolchain:user_toolchain",
             build_path)
-
 
         self.output.info(
             f"clang_tidy_config_path: {clang_tidy_config_path}")


### PR DESCRIPTION
- With the "newlib" settings, `prebuilt-picolibc` package and the soon coming picolibc library package, this detection is no longer valid or useful with the newer revisions of arm-gnu-toolchain which strip picolibc from the build process.
- :arrow_up: bump version to 4.0.0